### PR TITLE
fix(signup): add emailRedirectTo; feat: diagnostics page

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -94,6 +94,7 @@ export default function SignUpPage() {
         email: formData.email,
         password: formData.password,
         options: {
+          emailRedirectTo: `${window.location.origin}/auth/verify-email`,
           data: {
             first_name: formData.firstName,
             last_name: formData.lastName,

--- a/src/app/diagnostics/page.tsx
+++ b/src/app/diagnostics/page.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Navigation } from '@/components/navigation'
+import { Footer } from '@/components/footer'
+import { createSupabaseClient } from '@/lib/supabase'
+
+export default function DiagnosticsPage() {
+  const supabase = createSupabaseClient()
+  const [env, setEnv] = useState<any>(null)
+  const [authHealth, setAuthHealth] = useState<any>(null)
+  const [coursesCount, setCoursesCount] = useState<number | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setEnv({
+      NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? 'present' : 'missing'
+    })
+    const run = async () => {
+      try {
+        const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/health`
+        const res = await fetch(url!, { headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! } })
+        setAuthHealth({ status: res.status, ok: res.ok })
+      } catch (e: any) {
+        setError(e?.message || 'Failed to fetch auth health')
+      }
+      const { count } = await supabase.from('courses').select('*', { count: 'exact', head: true })
+      setCoursesCount(count ?? null)
+    }
+    run()
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">Diagnostics</h1>
+        {error && <div className="bg-red-50 text-red-700 border border-red-200 p-3 rounded">{error}</div>}
+        <div className="bg-white border rounded p-4">
+          <div className="font-semibold mb-2">Environment</div>
+          <pre className="text-sm text-gray-700">{JSON.stringify(env, null, 2)}</pre>
+        </div>
+        <div className="bg-white border rounded p-4">
+          <div className="font-semibold mb-2">Auth Health</div>
+          <pre className="text-sm text-gray-700">{JSON.stringify(authHealth, null, 2)}</pre>
+        </div>
+        <div className="bg-white border rounded p-4">
+          <div className="font-semibold mb-2">Courses Count</div>
+          <div className="text-sm text-gray-700">{coursesCount ?? '—'}</div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+


### PR DESCRIPTION
Adds emailRedirectTo to signup to improve verification flow. Introduces /diagnostics to verify env (URL/key presence), auth health, and basic DB connectivity (courses count).\n\nUse this to stabilize live auth/data: set Vercel env vars, add Supabase Auth URLs for prod/preview, then check /diagnostics.\n